### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,9 +1,34 @@
-Revision history for CSS-SpriteMaker
+Revision history for Perl module CSS::SpriteMaker
 
-0.00    Thu 23 May 2013 22:02:09 BST
-        * initial commit
+0.07    2013-09-15 18:44:14 BST
+        * allow custom target image filename in CSS stylesheet generation
+        * allow override of the generated CSS class name (e.g., add a prefix)
+        * remove '+' characters during CSS class generation
+        * allow parts of combined layout to be hidden in CSS
+        * nicer html preview of CSS image sprites
+        * allow composite layouts without glue layout
 
-0.01    Wed Jun 26 19:18:08 BST 2013
+0.06    2013-08-19 22:36:00 BST
+        * fix POD
+
+0.05    2013-08-19 07:44:25 BST
+        * allow composite layouts (layouts of layouts!)
+        * fix bug in Packed Layout by porting packing algorithm
+          from python glue
+
+0.04    2013-08-17 02:01:39 BST
+        * updated distribution metadata and version numbers
+
+0.03    2013-08-17 00:53:30 BST
+        * FixedDimension layout algorithm
+        * test FixedDimension layout algorithm
+        * pluggable layouts can now accept parameters
+
+0.02    2013-06-30 14:40:08 BST
+        * improved CSS class names generation
+        * improved POD
+
+0.01    2013-06-26 19:18:08 BST
         * first release!
         * make CSS image sprite
         * make HTML sample page
@@ -14,29 +39,6 @@ Revision history for CSS-SpriteMaker
         * border removal
         * tests
 
-0.02    Sun Jun 30 14:40:08 BST 2013
-        * improved CSS class names generation
-        * improved POD
+0.00    2013-05-23 22:02:09 BST
+        * initial commit
 
-0.03    Sat 17 Aug 2013 00:53:30 BST
-        * FixedDimension layout algorithm
-        * test FixedDimension layout algorithm
-        * pluggable layouts can now accept parameters
-
-0.04    Sat 17 Aug 2013 02:01:39 BST
-        * updated distribution metadata and version numbers
-
-0.05    Mon 19 Aug 2013 07:44:25 BST
-        * allow composite layouts (layouts of layouts!)
-        * fix bug in Packed Layout by porting packing algorithm from python glue
-
-0.06    Mon 19 Aug 2013 22:36:00 BST
-        * fix POD
-
-0.07    Sun 15 Sep 2013 18:44:14 BST
-        * allow custom target image filename in CSS stylesheet generation
-        * allow override of the generated CSS class name (e.g., add a prefix)
-        * remove '+' characters during CSS class generation
-        * allow parts of combined layout to be hidden in CSS
-        * nicer html preview of CSS image sprites
-        * allow composite layouts without glue layout


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec:
- Reversed the order so most recent release is listed first
- Changed the date format to ISO 8601

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
