### PR TITLE
Make compose_sprite() consistent under Perl 5.18 hash key ordering

### DIFF
--- a/lib/CSS/SpriteMaker.pm
+++ b/lib/CSS/SpriteMaker.pm
@@ -488,7 +488,7 @@ EOCSS
     print $fh '</style></head><body><h1>CSS::SpriteMaker Image Information</h1>';
 
     # html
-    for my $id (keys %$rh_sources_info) {
+    for my $id (sort { $a <=> $b } keys %$rh_sources_info) {
         my $rh_source_info = $rh_sources_info->{$id};
         
         my $css_class = $self->_generate_css_class_name($rh_source_info->{name});
@@ -544,13 +544,13 @@ EONCLICK
             print $fh "  <div class=\"item\" style=\"width: ${width}px; height: ${height}px;\"></div>";
         }
         print $fh "  <div class=\"item_description\">";
-        for my $key (keys %$rh_source_info) {
+        for my $key (sort keys %$rh_source_info) {
             next if $key eq "colors";
             print $fh "<b>" . $key . "</b>: " . ($rh_source_info->{$key} // 'none') . "<br />";
         }
         print $fh '<h3>Colors</h3>';
             print $fh "<b>total</b>: " . $rh_source_info->{colors}{total} . '<br />';
-            for my $colors (keys %{$rh_source_info->{colors}{map}}) {
+            for my $colors (sort keys %{$rh_source_info->{colors}{map}}) {
                 my ($r, $g, $b, $a) = split /,/, $colors;
                 my $rrgb = $r * 255 / $self->{color_max};
                 my $grgb = $g * 255 / $self->{color_max};
@@ -603,7 +603,7 @@ sub get_css_info_structure {
 
     my @css_info;
 
-    for my $id (keys %$rh_sources_info) {
+    for my $id (sort { $a <=> $b } keys %$rh_sources_info) {
         my $rh_source_info = $rh_sources_info->{$id};
         my $css_class = $rh_id_to_class->{$id};
 
@@ -640,7 +640,7 @@ sub _generate_css_class_names {
     my %id_to_class_mapping;
 
     PROCESS_SOURCEINFO:
-    for my $id (keys %$rh_source_info) {
+    for my $id (sort { $a <=> $b } keys %$rh_source_info) {
         
         next PROCESS_SOURCEINFO if !$rh_source_info->{$id}{include_in_css};
 
@@ -1244,7 +1244,7 @@ sub _write_image {
 
     # place each image according to the layout
     ITEM_ID:
-    for my $source_id (sort { $a <=> $b } $Layout->get_item_ids) {
+    for my $source_id ($Layout->get_item_ids) {
         my $rh_source_info = $rh_sources_info->{$source_id};
         my ($layout_x, $layout_y) = $Layout->get_item_coord($source_id);
 
@@ -1493,7 +1493,7 @@ sub _compose_sprite_with_glue {
     for my $rh_part (@parts) {
 
         my $rh_sources_info = $self->_ensure_sources_info(%$rh_part);
-        for my $key (keys %$rh_sources_info) {
+        for my $key (sort { $a <=> $b } keys %$rh_sources_info) {
             $global_sources_info{$key} = $rh_sources_info->{$key};
         }
 
@@ -1527,7 +1527,7 @@ sub _compose_sprite_with_glue {
     # we need to adjust the position of each element of the layout according to
     # the positions of the elements in $LayoutOfLayouts
     my $FinalLayout;
-    for my $layout_id (sort { $a <=> $b } $LayoutOfLayouts->get_item_ids()) {
+    for my $layout_id ($LayoutOfLayouts->get_item_ids()) {
         my $Layout = $layouts[$layout_id];
         my ($dx, $dy) = $LayoutOfLayouts->get_item_coord($layout_id);
         $Layout->move_items($dx, $dy);
@@ -1579,7 +1579,7 @@ sub _compose_sprite_without_glue {
         # keep composing the global sources_info structure
         # as we find new images... we will need this later
         # when we actually write the image.
-        for my $key (keys %$rh_sources_info) {
+        for my $key (sort { $a <=> $b } keys %$rh_sources_info) {
             $global_sources_info{$key} = $rh_sources_info->{$key};
         }
 
@@ -1592,7 +1592,6 @@ sub _compose_sprite_without_glue {
         else {
             # tweak the $rh_sources_info to include a new
             # fake image (the previously created layout)
-            my $max_id = max keys %$rh_sources_info;
             my $fake_img_id = $self->_get_image_id();
             $rh_sources_info->{$fake_img_id} = {
                 name => 'FakeImage' . $i,
@@ -1648,8 +1647,8 @@ sub _generate_color_histogram {
     my $rh_source_info = shift;
 
     my %histogram;
-    for my $id (keys %$rh_source_info) {
-        for my $color (keys %{ $rh_source_info->{$id}{colors}{map} }) {
+    for my $id (sort { $a <=> $b } keys %$rh_source_info) {
+        for my $color (sort keys %{ $rh_source_info->{$id}{colors}{map} }) {
             my $rah_colors_info = $rh_source_info->{$id}{colors}{map}{$color};
 
             $histogram{$color} = scalar @$rah_colors_info;

--- a/lib/CSS/SpriteMaker/Layout.pm
+++ b/lib/CSS/SpriteMaker/Layout.pm
@@ -179,7 +179,7 @@ Returns the id of each item into an array.
 
 sub get_item_ids {
     my $self = shift;
-    return keys %{$self->{items}};
+    return sort { $a <=> $b } keys %{$self->{items}};
 }
 
 =head2 get_layout_ascii_string

--- a/lib/CSS/SpriteMaker/Layout/DirectoryBased.pm
+++ b/lib/CSS/SpriteMaker/Layout/DirectoryBased.pm
@@ -89,6 +89,8 @@ sub _layout_items {
         $rh_items_info->{$a}{pathname}
             cmp
         $rh_items_info->{$b}{pathname}
+
+        || $a <=> $b
     }
     keys %$rh_items_info;
     

--- a/lib/CSS/SpriteMaker/Layout/FixedDimension.pm
+++ b/lib/CSS/SpriteMaker/Layout/FixedDimension.pm
@@ -110,7 +110,7 @@ sub _layout_items {
     my $dimension_size = 0;
 
     my $i = 0;
-    for my $id (keys %$rh_items_info) {
+    for my $id (sort keys %$rh_items_info) {
         my @wh = ($rh_items_info->{$id}{width}, $rh_items_info->{$id}{height});
 
         # condition to switch to the next row

--- a/lib/CSS/SpriteMaker/Layout/Packed.pm
+++ b/lib/CSS/SpriteMaker/Layout/Packed.pm
@@ -91,6 +91,8 @@ sub _layout_items {
             $rh_items_info->{$b}{height}
                 <=>
             $rh_items_info->{$a}{height}
+
+            || $a <=> $b
         }
         keys %$rh_items_info;
 

--- a/t/03-get_css_info_structure.t
+++ b/t/03-get_css_info_structure.t
@@ -167,22 +167,23 @@ my $bubble_extra_padding = 50;
 
     my $ra_structure = $SpriteMaker->get_css_info_structure();
 
-    is_deeply($ra_structure, [{
-        'css_class' => 'bubble',
-        'y' => $bubble_extra_padding,
-        'x' => $bubble_extra_padding,
-        'full_path' => 'sample_icons/bubble.png',
-        'width' => $bubble_width,
-        'height' => $bubble_height,
-    },
-    {
-        'width' => $apple_padded_width,
-        'y' => 0,
-        'css_class' => 'apple',
-        'x' => 132,
-        'full_path' => 'sample_icons/apple.png',
-        'height' => $apple_padded_height
-    }
+    is_deeply($ra_structure, [
+        {
+            'width' => $apple_padded_width,
+            'y' => 0,
+            'css_class' => 'apple',
+            'x' => 132,
+            'full_path' => 'sample_icons/apple.png',
+            'height' => $apple_padded_height
+        },
+        {
+            'css_class' => 'bubble',
+            'y' => $bubble_extra_padding,
+            'x' => $bubble_extra_padding,
+            'full_path' => 'sample_icons/bubble.png',
+            'width' => $bubble_width,
+            'height' => $bubble_height,
+        },
     ], 'only the bubble has extra padding');
 }
 


### PR DESCRIPTION
In Perl 5.18 the hash key order randomization was made much more random
much more often. For CSS::SpriteMaker this caused the order of composed
sprites to be random, whereas they should be in the order of the parts
arrayref argument.

Solution was basically to added a bunch of sort() calls in front of all
the calls to keys(), to ensure completely consistent ordering.
